### PR TITLE
Fixes wrong naming of log files with dagman

### DIFF
--- a/batch_processing.py
+++ b/batch_processing.py
@@ -73,12 +73,13 @@ def write_config_file(config,
 
 def write_option_file(config,
                       script_files,
+                      run_numbers,
                       job_file,
                       scratch_folder):
     process_name = '{dataset_number}_{step_name}'.format(**config)
 
     lines = []
-    for i, script_i in enumerate(script_files):
+    for i, script_i in zip(run_numbers, script_files):
         job_name = '{}_{}'.format(process_name, i)
         lines.append('JOB {} {}'.format(job_name, job_file))
         lines.append('VARS {} script_file="{}" run="{}"'.format(
@@ -93,11 +94,13 @@ def write_option_file(config,
 
 def create_dagman_files(config,
                         script_files,
+                        run_numbers,
                         scratch_folder):
     config_file = write_config_file(config, scratch_folder)
     onejob_file = write_onejob_file(config, scratch_folder)
     options_file = write_option_file(config,
                                      script_files,
+                                     run_numbers,
                                      onejob_file,
                                      scratch_folder)
     cmd = 'condor_submit_dag -config {} -notification Complete {}'.format(
@@ -133,6 +136,7 @@ def adjust_resouces(config, script_files, scratch_folder):
 
 def create_pbs_files(config,
                      script_files,
+                     run_numbers,
                      scratch_folder):
     pass
 

--- a/simulation_scripts.py
+++ b/simulation_scripts.py
@@ -72,6 +72,7 @@ def write_job_files(config, step, check_existing=False):
     if not os.path.isdir(log_dir):
         os.makedirs(log_dir)
     scripts = []
+    run_numbers = []
     for i in range(config['n_runs']):
         config['run_number'] = i
         config['run_folder'] = get_run_folder(i)
@@ -94,7 +95,8 @@ def write_job_files(config, step, check_existing=False):
         st = os.stat(script_path)
         os.chmod(script_path, st.st_mode | stat.S_IEXEC)
         scripts.append(script_path)
-    return scripts
+        run_numbers.append(i)
+    return scripts, run_numbers
 
 
 def build_config(data_folder, custom_settings):
@@ -199,7 +201,7 @@ def main(data_folder,
                 default=default)
         config['processing_scratch'] = os.path.abspath(processing_scratch)
 
-    script_files = write_job_files(config, step, check_existing=resume)
+    script_files, run_numbers = write_job_files(config, step, check_existing=resume)
 
     if dagman or pbs:
         scratch_subfolder = '{dataset_number}_{step_name}'.format(**config)
@@ -210,10 +212,12 @@ def main(data_folder,
         if dagman:
             create_dagman_files(config,
                                 script_files,
+                                run_numbers,
                                 scratch_folder)
         if pbs:
             create_pbs_files(config,
                              script_files,
+                             run_numbers,
                              scratch_folder)
 
 


### PR DESCRIPTION
Fixes correct numbering of log files when  running simulation_scripts.py with --resume option by additionally returning and using a list of run_numbers